### PR TITLE
Feature/fix nfs provisioner version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ This repo contains an example of deploying 3scale on your laptop, on [k3d](https
 * k3d - e.g. `brew install k3d`
 * ansible (for generating the k8s templates)
 
+### RWX PVC support
+
+* 3scale System component needs a RWC PVC for `system-storage`:
+  * Configuration files read by the System component at run-time
+  * Static files (HTML, CSS, JS, etc) uploaded to System by its CMS feature, for the purpose of creating a Developer Portal
+  * Note that System can be scaled horizontally with multiple pods uploading and reading said static files, hence the need for a RWX PersistentVolume
+* For dev purpose, it can deployed on the k8s cluster a small [nfs-provisioner](kubernetes/nfs/) in order to create a RWX `PersistentVolumeClaim` without using S3 or any external NFS...
+  * 3scale templates: specify template variable `RWX_STORAGE_CLASS` to value `nfs`
+  * 3scale operator: specify `APIManager` CR variable `StorageClassName` to value `nfs`
+  ```yaml
+  apiVersion: apps.3scale.net/v1alpha1
+  kind: APIManager
+  metadata:
+    name: your-apimanager
+    namespace: your-namespace
+  spec:
+    wildcardDomain: YOUR-WILDCARD.apps.CLUSTER-NAME.dev.3sca.net
+    resourceRequirementsEnabled: false
+    system:
+      fileStorage:
+        persistentVolumeClaim:
+          storageClassName: nfs
+  ```
+* Example of [system-storage-pvc](kubernetes/system-storage-pvc.yml)
+
 ### Usage
 
 1. `make` or `make help` - for usage instructions
@@ -23,7 +48,3 @@ This repo contains an example of deploying 3scale on your laptop, on [k3d](https
 1. Go to https://master-account.127.0.0.1.nip.io:8443 on your browser
 1. Accept the self-signed certificate warning
 1. Login with username `master` and password the value that you'll find in `$PROJECT_ROOT/3scale_k8s/playbook/passwords/master_password`.
-
-
-    
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repo contains an example of deploying 3scale on your laptop, on [k3d](https
   * Configuration files read by the System component at run-time
   * Static files (HTML, CSS, JS, etc) uploaded to System by its CMS feature, for the purpose of creating a Developer Portal
   * Note that System can be scaled horizontally with multiple pods uploading and reading said static files, hence the need for a RWX PersistentVolume
-* For dev purpose, it can deployed on the k8s cluster a small [nfs-provisioner](kubernetes/nfs/) in order to create a RWX `PersistentVolumeClaim` without using S3 or any external NFS...
+* For dev purposes, a small [nfs-provisioner](kubernetes/nfs/) can be deployed in the k8s cluster in order to create a RWX `PersistentVolumeClaim` without using S3 or any external NFS...
   * 3scale templates: specify template variable `RWX_STORAGE_CLASS` to value `nfs`
   * 3scale operator: specify `APIManager` CR variable `StorageClassName` to value `nfs`
   ```yaml

--- a/kubernetes/nfs/statefulset.yaml
+++ b/kubernetes/nfs/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:latest
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v2.2.2
           ports:
             - name: nfs
               containerPort: 2049


### PR DESCRIPTION
Features:
- Fix nfs-provisioner image version. It was pointing to `latest`version and was not working now. During the hackton, `latest` version was `v2.2.2`, but a month ago `latest` tag  was updated to `v2.3.0` and it stopped working due to permission issues. Due to being just a PoC (not something productive), I fixed the image to the working one.
- I added a bit of documentation about the need of RWX support for system. Some Solution Architects are asking for light k8s 3scale solution for demos/workshops... and they need RWX support for system-storage. From now on, I will redirect them to that repo, where they can find information about 3scale running on vanilla k8s and information about a simple solution for RWX PVC with `nfs-provisioner`